### PR TITLE
Removed conflicting colour prop

### DIFF
--- a/src/components/modal/multiStepModal/index.tsx
+++ b/src/components/modal/multiStepModal/index.tsx
@@ -24,7 +24,6 @@ export const ModalWrapper = (props: Props) => {
     <Layer
       onEsc={props.closeModal}
       onClickOutside={props.closeModal}
-      background={"background"}
       modal
     >
       <Box pad={"medium"} width={"large"}>


### PR DESCRIPTION
## Re: #8 
### Overview
Investigated modal rendering and realized background prop was being passed to layer component. It was not behaving as expected and issue was resolved when this background prop was removed. 
### Testing
Successfully tested in dark mode and light mode in both Chrome & Safari.
#### More Information
For further information on the Grommet Layer component click [here](https://v2.grommet.io/layer#background).